### PR TITLE
Add option for ssh tunnels between compute and login nodes

### DIFF
--- a/blue_pebble/bin/lcmd
+++ b/blue_pebble/bin/lcmd
@@ -11,9 +11,6 @@ parser.add_argument('--mins',          type=int, nargs='?', default=0,  help="ti
 parser.add_argument('--memory',  '-m', type=int, nargs='?', default=22, help="memory in gp")
 parser.add_argument('--queue',   '-q', type=str, nargs='?',             help="queue")
 parser.add_argument('--gputype',       type=str, nargs='?'             )#choices=["GTX1080", "RTX2080", "RTX2080Ti", "RTX3090"], help="{GTX1080, RTX2080, RTX2080Ti, RTX3090}")
-parser.add_argument('--venv',          type=str, nargs='?')
-parser.add_argument('--cmd',           type=str, nargs='?',             help="job command --- must be last argument")
-parser.add_argument('--autoname', action='store_true',                   help="extract output filename based on job --- always uses third argument after --cmd, as in --cmd python file.py output_filename")
 
 # remove args after --cmd, if present
 if "--cmd" in sys.argv:

--- a/blue_pebble/bin/lcmd
+++ b/blue_pebble/bin/lcmd
@@ -21,7 +21,7 @@ if "--cmd" in sys.argv:
     arglist = sys.argv[1:cmd_idx]
 else:
     arglist = sys.argv[1:]
-args = parser.parse_args(arglist)
+args,_ = parser.parse_known_args(arglist)
 
 cmd = ""
 

--- a/blue_pebble/bin/lcmd
+++ b/blue_pebble/bin/lcmd
@@ -17,7 +17,7 @@ parser.add_argument('--autoname', action='store_true',                   help="e
 
 # remove args after --cmd, if present
 if "--cmd" in sys.argv:
-    cmd_idx = arglist.index('--cmd')
+    cmd_idx = sys.argv.index('--cmd')
     arglist = sys.argv[1:cmd_idx]
 else:
     arglist = sys.argv[1:]

--- a/blue_pebble/bin/lcmd
+++ b/blue_pebble/bin/lcmd
@@ -16,7 +16,7 @@ parser.add_argument('--cmd',           type=str, nargs='?',             help="jo
 parser.add_argument('--autoname', action='store_true',                   help="extract output filename based on job --- always uses third argument after --cmd, as in --cmd python file.py output_filename")
 
 # remove args after --cmd, if present
-if "--cmd" in arglist:
+if "--cmd" in sys.argv:
     cmd_idx = arglist.index('--cmd')
     arglist = sys.argv[1:cmd_idx]
 else:

--- a/blue_pebble/bin/lscript
+++ b/blue_pebble/bin/lscript
@@ -14,6 +14,7 @@ parser.add_argument('--memory',  '-m', type=int, nargs='?',             help="me
 parser.add_argument('--queue',   '-q', type=str, nargs='?',             help="queue")
 parser.add_argument('--gputype',       type=str, nargs='?')#,             choices=["GTX1080", "RTX2080", "RTX2080Ti", "RTX3090"], help="{GTX1080, RTX2080, RTX2080Ti, RTX3090}")
 parser.add_argument('--venv',          type=str, nargs='?')
+parser.add_argument('--port',          type=str, nargs='*',             help="ports to open ssh tunnels back to login nodes")
 parser.add_argument('--cmd',           type=str, nargs='*',             help="job command --- must be last argument")
 parser.add_argument('--autoname', action='store_true',                   help="extract output filename based on job --- always uses third argument after --cmd, as in --cmd python file.py output_filename")
 #parser.add_argument('ssd', '-s', action=store_true)
@@ -33,6 +34,11 @@ if args.autoname:
 
 print('')
 print('cd $SLURM_SUBMIT_DIR')
+
+if args.port:
+    for i in range(1,6):
+        for port in args.port:
+            print(f"/usr/bin/ssh -N -f -R {port}:localhost:{port} bp1-login0{i}.data.bp.acrc.priv")
 
 print('module add lib/hdf5/1.10.6-gcc')
 if args.venv is not None:


### PR DESCRIPTION
This adds a `--port` option to `lscript` which accepts a list of ports and will add commands to create ssh tunnels back to all 5 login nodes to the output script. The driving requirement for this is to make it easier to access Jupyter notebooks running on a compute node. Something like the following (give or take setting the venv/conda env) should work to allow this: `lsub --port 8910 --cmd "jupyter notebook --port 8910"` (and then `ssh -N -L 8910:localhost:8910 bp1-login.acrc.bris.ac.uk` will allow for a tunnel from your local machine to a Blue Pebble login node at which point opening http://localhost:8910 in a browser should work).

As a result a small change is made to `lcmd` to only try and parse known arguments (so it doesn't break because it doesn't recognise the new `--port` argument for `lscript`). This also means it's safe to remove arguments from `lcmd` that is doesn't use like `--cmd`, `--autoname` and `--venv`.

There's also a  small bug in lcmd which was trying to use a variable called `arglist` to find the `--cmd` option but that was not yet initialized and I think is meant to be `sys.argv`.

Based on http://www.utkuevci.com/notes/port-forwarding/ 
For more about ssh tunnels: https://unix.stackexchange.com/questions/46235/how-does-reverse-ssh-tunneling-work/118650#118650

NB my version of these scripts has diverged a bit so this as fully tested as I'd like.
