### PR TITLE
Guidance on running Jupyter on Blue Pebble

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Unfortunately, these scripts tend to produce a huge number of files that look li
 ```
 lbatch -c 1 -g 1 -m 22 --autoname --cmd python my_training_script.py output_filename --my_command_line_arg
 ```
-`--autoname` assumes that the job's output filename comes in third place (after `python` and `my_training_script.py`), 
+`--autoname` assumes that the job's output filename comes in third place (after `python` and `my_training_script.py`),
 and produces logs with the name: `output_filename.o`, which tends to be much more helpful for working out which log-file
 belongs to which job.  This may require you to use `print('...', flush=True)`, to make sure that the printed output isn't buffered.
 
@@ -34,13 +34,15 @@ lint -g 1
 This should only be used for debugging code (not for running it).  And you should be careful to close it after you're done.
 
 ## Recommended resource limits
-The standard GPU nodes come with 8 CPUs, 96 GB of memory, and 4 GPUs.  
+The standard GPU nodes come with 8 CPUs, 96 GB of memory, and 4 GPUs.
 Therefore for maximum usage of the GPUs, it makes sense to use 1 or 2 CPUs and up to 22 GB of memory per CPU (to use some for the system).
 
 ## Logging in to Blue Pebble
 I have a hatred of VPNs.  You can login to Blue Pebble without going through the VPN using `local_bin/bp_ssh`. (You'll need to update it with your username though!)
 
-I have also included `local_bin/bp_jupyter` which will forward a port from the login-node onto your local computer, so that you can run Jupyter on the login node.
+## Guides
+
+* [Running Jupyter in Blue Pebble](instructions/jupyter-on-blue-pebble.md)
 
 ## Disk space in Blue Pebble
 Disk space is tightly constrained (only 20 GB in home).  Use your 1T work directory (in my case `/work/ei19760/`) which has fewer guarantees on backup etc.  These directories can be found in `$HOME` and `$WORK`.  To check your disk space, use
@@ -78,7 +80,7 @@ If you don't want that, there are other approaches such as `sshfs` which loads a
 [Instructions](https://github.com/LaurenceA/infrastructure/blob/master/instructions/Pycharm_BluePebble.pdf) from Michele
 
 ### Connecting VSCode to Blue Pebble
-* Install the [remote extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack).  The necessary extension in this use case is Remote-SSH. 
+* Install the [remote extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack).  The necessary extension in this use case is Remote-SSH.
 * Connect to the VPN.
 * Select `Remote-SSH: Connect to Host...` from the VSCode Command Palette, then enter user@bp1-login.acrc.bris.ac.uk.
 * Local extensions will not be available on the remote initialisation. Remote and local settings can be synced. Solutions to this and further information on all of the above with FAQ and troubleshooting are detailed in the VS Code [documentation](https://code.visualstudio.com/docs/remote/ssh).

--- a/blue_pebble/bin/lqueue
+++ b/blue_pebble/bin/lqueue
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-squeue -u ei19760
+squeue --me

--- a/instructions/jupyter-on-blue-pebble.md
+++ b/instructions/jupyter-on-blue-pebble.md
@@ -1,0 +1,94 @@
+# Work on a Jupyter notebook on Blue Pebble
+
+The simplest option to run the Jupyter server on the login node.
+However, sometimes this is not desirable. Perhaps you want more resources than a login node provides or you don't want to have to manage keeping the process running if you don't maintain a network connection.
+
+Another option is to run the Jupyter server on a compute node by queuing it as a job through Slurm.
+There are two ways to achieve this: as a batch job on a compute node or as an interactive job on a compute node.
+SSH tunnels are used to connect the port used by Jupyter on the compute node back to the login nodes.
+
+Whether you run on login node or compute node you will need to open an SSH tunnel from your local machine to a login node.
+
+## Assumptions
+
+This guide makes the following assumptions:
+
+* You have Jupyter installed on Blue Pebble. It also assumes that if you have environments managed by tools like `conda` or `venv` you are able to adjust the commands to activate the environments (e.g. `--venv` argument for `lbatch`).
+* You have a port to use since someone else might have taken the default 8888. For the commands below `<<<PORT>>>` should be replaced with your chosen port. You can use the following to choose a random one before you start: `shuf -i 6000-9999 -n 1`.
+* The commands below are all proceeded by the machine on which to run them - either your local machine, a Blue Pebble login node or a Blue Pebble compute node.
+* You want a notebook server. If you want something else like Jupyter Lab then update the commands, e.g replace `jupyter notebook` with `jupyter lab`.
+* If you don't want to have to dig the security token out of the server logs each time then you can set a password for authentication with Jupyter instead.
+
+```
+bp-login $ jupyter notebook password
+```
+
+## Warning
+
+Don't forget to cancel any batch or interactive jobs and stop any processes on the login nodes once you're done. The example commands below limit the jobs to 8 hours in case you forget.
+
+## Option 1: Batch job
+
+```
+bp-login $ port=<<<PORT>>>
+bp-login $ cd my/directory/of/notebooks
+bp-login $ lbatch --hours 8 --port ${port} --cmd "jupyter notebook --no-browser --port ${port}"
+```
+
+Once the job starts running on the cluster, a file called `slurm-JOBID.out` will include the output for the jupyter command including the server logs so check it to determine when the Jupyter server is up and running.
+
+Don't forget to cancel the job once you've finished.
+
+## Option 2: Interactive job
+
+This way is more typing and you will want to use something like screen or tmux to keep the jupyter process running in case you lose network connection. The advantage of being interactive is the live feedback from the commands so you'll know immediately when you have a compute node and when Jupyter is running.
+
+```
+bp-login $ cd my/directory/of/notebooks
+bp-login $ lint
+```
+
+This will eventually leave you with a shell on a compute node at which point you can open SSH tunnels back from the login nodes and start Jupyter:
+
+```
+bp-compute $ port=<<<PORT>>>
+bp-compute $ for i in 1 2 3 4 5; do /usr/bin/ssh -N -f -R ${port}:localhost:${port} bp1-login0${i}.data.bp.acrc.priv; done
+bp-compute $ jupyter notebook --no-browser --port ${port}
+```
+
+Don't forget to kill the interactive job once you've finished.
+
+## Option 3: Login node
+
+```
+bp-login $ port=<<<PORT>>>
+bp-login $ cd my/directory/of/notebooks
+bp-login $ jupyter notebook --port ${port} --no-browser
+```
+
+## Opening a notebook in a browser
+
+Whichever approach you choose you will need to open an SSH tunnel from your local machine to a login node.
+NB your port will need to match the one used to by the Jupyter server.
+
+```
+local $ port=<<<PORT>>>
+local $ ssh -N -f -L localhost:${port}:localhost:${port} -J seis blue-pebble
+```
+
+At this point you can point your local browser to `http://localhost:<<<PORT>>>`.
+
+## One line helper
+
+The script [local_bin/bp_jupyter](../local_bin/bp_jupyter) will:
+1. Pick a random port
+2. Submit a job to run Jupyter notebook on a compute node with needed SSH tunnels on the cluster
+3. Open an ssh tunnel to the login node
+
+e.g.
+```
+local $ local_bin/bp_jupyter --hours 8
+```
+The options you pass will be given to lscript and lcmd so you can use them to set your job resource needs.
+
+The downside is that it will run the Jupyter server in your home directory and you will still need to cancel the job when your are finished.

--- a/instructions/jupyter-on-blue-pebble.md
+++ b/instructions/jupyter-on-blue-pebble.md
@@ -92,3 +92,5 @@ local $ local_bin/bp_jupyter --hours 8
 The options you pass will be given to lscript and lcmd so you can use them to set your job resource needs.
 
 The downside is that it will run the Jupyter server in your home directory and you will still need to cancel the job when your are finished.
+
+The script also assume you have create an alias in your local SSH config which points bp at Blue Pebble login node with the correct username.

--- a/local_bin/bp_jupyter
+++ b/local_bin/bp_jupyter
@@ -1,3 +1,10 @@
-ssh -N -f -L localhost:8896:localhost:8896 -J ei19760@seis.bris.ac.uk ei19760@bp1-login01b.acrc.bris.ac.uk
-#run this remotely to start Jupyter listening on localhost:8896
-#jupyter lab --no-browser -port=8896
+#!/bin/env bash
+
+set -euo pipefail
+
+port=$(shuf -i 6000-9999 -n 1)
+echo "Using port $port"
+echo "Once the job has started on the cluster, navigate to http://localhost:${port}"
+ssh -t -L ${port}:localhost:${port} bp "lsub $@ --port ${port} --cmd 'jupyter notebook --no-browser --port ${port}'"
+
+echo "Connection closed. Please make sure the job is cancelled."

--- a/local_bin/bp_jupyter
+++ b/local_bin/bp_jupyter
@@ -5,6 +5,8 @@ set -euo pipefail
 port=$(shuf -i 6000-9999 -n 1)
 echo "Using port $port"
 echo "Once the job has started on the cluster, navigate to http://localhost:${port}"
+echo "If the connection closes prematurely then run 'ssh -N -L ${port}:localhost:${port} bp' to re-open the tunnel."
+
 ssh -t -L ${port}:localhost:${port} bp "lsub $@ --port ${port} --cmd 'jupyter notebook --no-browser --port ${port}'"
 
 echo "Connection closed. Please make sure the job is cancelled."


### PR DESCRIPTION
* A set of instructions for different ways to run Jupyter on Blue Pebble
* Change local_bin/bp_jupyter to both queue a job and open all the SSH tunnels (both compute node-login node and local-login node) all in one go (on a random port)
* Change lqueue to show my jobs rather than just Laurence's!